### PR TITLE
Update to LibPressio 0.96.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libpressio" %}
-{% set version = "0.94.0" %}
+{% set version = "0.96.0" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
This fixes a bug that causes a crash with newer versions of numpy.  I wasn't sure how to build this, so please attempt the build before merging.